### PR TITLE
fix: fall back on manifest.licenses (#4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ module.exports = {
 and then:
 
 ```
-yarn import plugin https://raw.githubusercontent.com/tophat/yarn-plugin-licenses/master/bundles/%40yarnpkg/plugin-licenses-audit.js
+yarn plugin import https://raw.githubusercontent.com/tophat/yarn-plugin-licenses/master/bundles/@yarnpkg/plugin-licenses-audit.js
 yarn licenses audit --output-file=- --config=licenses.config.js
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -292,16 +292,25 @@ class AuditLicensesCommand extends Command<CommandContext> {
         }
     }
 
+    coerceToString(field: unknown) {
+        const string = String(field);
+        return (typeof field === 'string' || field === string) ? string : null;
+    }
+
     parseLicenseManifestField(field: unknown): string | null {
         if (Array.isArray(field)) {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const licenses = field as Array<any>
-            return String(licenses[0]?.type ?? '')
+            const licenseTypes = licenses.reduce((licenseTypes, license) => {
+                const type = coerceToString(license.type);
+                if (type) {
+                    licenseTypes.push(type);
+                }
+                return licenseTypes;
+            }, []);
+            return licenseTypes.length ? `(${licenseTypes.join(' AND ')})` : '';
         }
-        if (typeof field === 'string' || field === String(field)) {
-            return String(field)
-        }
-        return null
+        return coerceToString(field);
     }
 
     async parseLicense({


### PR DESCRIPTION
## Description

If the license property is absent from the manifest, and we are running in loose mode, then check the deprecated licenses property for an array of licenses. Conservatively coerce them to a conjunctive (ANDs) SPDX license expression since it is ambiguous whether the licenses are meant to be interpreted conjunctively (ANDs) or disjunctively (ORs).

## Related Issues

- Closes #4, some old packages like [json-schema@0.2.3](https://github.com/kriszyp/json-schema/tree/v0.2.3/package.json) and [exit@0.1.2](https://github.com/cowboy/node-exit/tree/v0.1.2/package.json) use [the deprecated `licenses` property in their package.json](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#license) without using the recommended `license` property.

## Checklist

- [x] I agree to abide by the [Code of Conduct](https://github.com/tophat/yarn-plugin-licenses/blob/master/CODE_OF_CONDUCT.md).
- [x] This PR has sufficient documentation.
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

There are a variety of alternative solutions to consider, and I have discussed a few of them in the related issue. This pull request is intended to open a dialogue. I encountered an obstacle testing this change, so it should be verified before being accepted. `yarn install` crashed for me with a permissions error because some dependencies assume CLI tools are globally installed instead of running them with `yarn run`.