### PR TITLE
fix: Use strict mode in all .js files (#12).

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,5 @@
+'use strict'
+
 module.exports = {
     root: true,
     parser: '@typescript-eslint/parser',

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Yarn Berry plugin to enforce valid licenses used in a project.
 Define a `licenses.config.js` file:
 
 ```js
+'use strict'
+
 module.exports = {
     isValidLicense: (license) => {
         const valid = new RegExp('\\b(mit|apache\\b.*2|bsd|isc|unlicense)\\b', 'i')
@@ -20,6 +22,8 @@ module.exports = {
 or
 
 ```js
+'use strict'
+
 module.exports = {
     isValidLicense: new RegExp('\\b(mit|apache\\b.*2|bsd|isc|unlicense)\\b', 'i'),
     ignorePackages: ['react'],

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,5 @@
+'use strict'
+
 module.exports = {
     presets: [
         [

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,2 +1,4 @@
+'use strict'
+
 module.exports = { extends: ['@tophat/commitlint-config'] }
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const CI = process.env.CI === '1'
 const ARTIFACT_DIR = process.env.ARTIFACT_DIR || 'artifacts'
 


### PR DESCRIPTION
## Description

Use strict mode in all .js files.

## Related Issues

- Closes #12, use strict mode in the sample license files in the README.

## Checklist

- [x] I agree to abide by the [Code of Conduct](https://github.com/tophat/yarn-plugin-licenses/blob/master/CODE_OF_CONDUCT.md).
- [x] This PR has sufficient documentation.
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

This is intended predominantly to encourage use of strict mode in downstream projects that copy the sample config files.